### PR TITLE
feat: rebrand from ALLAD to Sivera

### DIFF
--- a/app/[lang]/(public)/cookies/CookiePolicyContent.tsx
+++ b/app/[lang]/(public)/cookies/CookiePolicyContent.tsx
@@ -433,9 +433,7 @@ export default function CookiePolicyContent() {
                 <FiMail className="w-5 h-5 text-primary" />
                 <p className="font-semibold">이메일</p>
               </div>
-              <p className="text-primary-700 ml-7">
-                allofadvertisements@gmail.com
-              </p>
+              <p className="text-primary-700 ml-7">sivera@sivera.app</p>
             </div>
           </CardBody>
         </Card>

--- a/app/[lang]/(public)/faq/FAQContent.tsx
+++ b/app/[lang]/(public)/faq/FAQContent.tsx
@@ -77,7 +77,7 @@ const faqData: FAQCategory[] = [
         id: "9",
         question: "Q9: 계정 연동 시 오류가 발생하면 어떻게 해야 하나요?",
         answer:
-          "A9: '광고 계정 연동/관리' 페이지에서 해당 계정의 오류 상태를 확인하고, 안내되는 오류 메시지 및 해결 가이드를 참고해 주세요. 대부분 API 접근 권한 만료 또는 변경 등의 문제이며, 재인증 절차를 통해 해결될 수 있습니다. 해결이 어려운 경우 고객 지원팀(allofadvertisements@gmail.com)에 문의해주시면 신속하게 도와드리겠습니다.",
+          "A9: '광고 계정 연동/관리' 페이지에서 해당 계정의 오류 상태를 확인하고, 안내되는 오류 메시지 및 해결 가이드를 참고해 주세요. 대부분 API 접근 권한 만료 또는 변경 등의 문제이며, 재인증 절차를 통해 해결될 수 있습니다. 해결이 어려운 경우 고객 지원팀(sivera@sivera.app)에 문의해주시면 신속하게 도와드리겠습니다.",
       },
     ],
   },
@@ -165,7 +165,7 @@ const faqData: FAQCategory[] = [
         id: "20",
         question: "Q20: 서비스 이용 중 문제가 발생하면 어디에 문의해야 하나요?",
         answer:
-          "A20: 서비스 내 '고객 지원' 페이지의 문의하기 양식을 이용하시거나, allofadvertisements@gmail.com 으로 문의해주시면 최대한 빠르게 답변드리겠습니다.",
+          "A20: 서비스 내 '고객 지원' 페이지의 문의하기 양식을 이용하시거나, sivera@sivera.app 으로 문의해주시면 최대한 빠르게 답변드리겠습니다.",
       },
       {
         id: "21",
@@ -214,16 +214,16 @@ export default function FAQContent() {
                   }
                 >
                   <div className="px-2 pb-2 whitespace-pre-wrap">
-                    {item.answer.includes("allofadvertisements@gmail.com") ? (
+                    {item.answer.includes("sivera@sivera.app") ? (
                       <span>
-                        {item.answer.split("allofadvertisements@gmail.com")[0]}
+                        {item.answer.split("sivera@sivera.app")[0]}
                         <a
                           className="text-primary hover:underline"
-                          href="mailto:allofadvertisements@gmail.com"
+                          href="mailto:sivera@sivera.app"
                         >
-                          allofadvertisements@gmail.com
+                          sivera@sivera.app
                         </a>
-                        {item.answer.split("allofadvertisements@gmail.com")[1]}
+                        {item.answer.split("sivera@sivera.app")[1]}
                       </span>
                     ) : (
                       item.answer

--- a/app/[lang]/(public)/privacy/PrivacyPolicyContent.tsx
+++ b/app/[lang]/(public)/privacy/PrivacyPolicyContent.tsx
@@ -704,10 +704,10 @@ export default function PrivacyPolicyContent() {
                     <FiMail className="w-4 h-4" />
                     <Link
                       color="primary"
-                      href="mailto:allofadvertisements@gmail.com"
+                      href="mailto:sivera@sivera.app"
                       underline="hover"
                     >
-                      allofadvertisements@gmail.com
+                      sivera@sivera.app
                     </Link>
                   </div>
                 </div>
@@ -731,10 +731,10 @@ export default function PrivacyPolicyContent() {
                     <FiMail className="w-4 h-4" />
                     <Link
                       color="secondary"
-                      href="mailto:allofadvertisements@gmail.com"
+                      href="mailto:sivera@sivera.app"
                       underline="hover"
                     >
-                      allofadvertisements@gmail.com
+                      sivera@sivera.app
                     </Link>
                   </div>
                 </div>

--- a/app/[lang]/(public)/refund-policy/RefundPolicyContent.tsx
+++ b/app/[lang]/(public)/refund-policy/RefundPolicyContent.tsx
@@ -220,8 +220,8 @@ export default function RefundPolicyContent() {
               <p className="font-semibold mb-2">3. 청약철회 방법</p>
               <p className="text-default-600">
                 회원은 청약철회를 하고자 하는 경우, 서비스 내 고객센터 또는
-                지정된 연락처(allofadvertisements@gmail.com 등)를 통해
-                서면(전자문서 포함)으로 청약철회 의사를 표시해야 합니다.
+                지정된 연락처(sivera@sivera.app 등)를 통해 서면(전자문서
+                포함)으로 청약철회 의사를 표시해야 합니다.
               </p>
             </div>
 
@@ -370,8 +370,8 @@ export default function RefundPolicyContent() {
               <li className="text-default-700">
                 제3조에 따른 청약철회(제한 사유에 해당하지 않는 경우) 또는 제5조
                 제5항 및 제6항에 따른 환불을 받고자 하는 회원은 서비스 내
-                고객센터 또는 지정된 연락처(allofadvertisements@gmail.com 등)를
-                통해 환불 요청 사유 및 필요한 정보를 제공해야 합니다.
+                고객센터 또는 지정된 연락처(sivera@sivera.app 등)를 통해 환불
+                요청 사유 및 필요한 정보를 제공해야 합니다.
               </li>
               <li className="text-default-700">
                 회사는 회원의 환불 요청을 접수한 후, 환불 사유 및 조건을
@@ -448,10 +448,10 @@ export default function RefundPolicyContent() {
                 <FiMail className="text-primary" />
                 <Link
                   color="primary"
-                  href="mailto:allofadvertisements@gmail.com"
+                  href="mailto:sivera@sivera.app"
                   underline="hover"
                 >
-                  allofadvertisements@gmail.com
+                  sivera@sivera.app
                 </Link>
               </div>
               <div className="flex items-center gap-2">

--- a/app/[lang]/(public)/terms/TermsOfServiceContent.tsx
+++ b/app/[lang]/(public)/terms/TermsOfServiceContent.tsx
@@ -958,10 +958,10 @@ export default function TermsOfServiceContent() {
             <FiMail className="text-primary" />
             <Link
               color="primary"
-              href="mailto:allofadvertisements@gmail.com"
+              href="mailto:sivera@sivera.app"
               underline="hover"
             >
-              allofadvertisements@gmail.com
+              sivera@sivera.app
             </Link>
           </div>
         </div>

--- a/app/[lang]/dictionaries/en.json
+++ b/app/[lang]/dictionaries/en.json
@@ -123,7 +123,7 @@
     "reports": "Reports"
   },
   "brand": {
-    "name": "A.ll + Ad"
+    "name": "Sivera"
   },
   "auth": {
     "login": {
@@ -833,7 +833,7 @@
       "tagline": "Setting new standards for ad management.",
       "copyright": "© {{year}} {{company}}. All rights reserved.",
       "address": "#402, 322, Byeollae 3-ro, Namyangju-si, Gyeonggi-do, Republic of Korea",
-      "email": "siveraofficial@gmail.com",
+      "email": "sivera@sivera.app",
       "phone": "+82.010.7727.7428"
     }
   },
@@ -920,14 +920,14 @@
   },
   "consent": {
     "title": "Advertising account permissions",
-    "description": "Permissions required for All-AD to access your ad accounts. Only the selected platforms will be granted access.",
+    "description": "Permissions required for Sivera to access your ad accounts. Only the selected platforms will be granted access.",
     "selectAll": "Select all platforms",
     "required": "Required",
     "requestedPermissions": "The following permissions will be requested:",
     "noticeTitle": "Important notes",
     "bullets": {
       "revokeAnytime": "You can revoke these permissions at any time in Settings.",
-      "scopeOnly": "All-AD only accesses data within the granted scope.",
+      "scopeOnly": "Sivera only accesses data within the granted scope.",
       "encrypted": "All data is encrypted and protected securely.",
       "privacy": "Data is processed in accordance with our Privacy Policy."
     },

--- a/app/[lang]/dictionaries/ko.json
+++ b/app/[lang]/dictionaries/ko.json
@@ -145,7 +145,7 @@
     "reports": "보고서"
   },
   "brand": {
-    "name": "A.ll + Ad"
+    "name": "Sivera"
   },
   "auth": {
     "login": {
@@ -855,7 +855,7 @@
       "tagline": "광고 관리의 새로운 기준을 제시합니다.",
       "copyright": "© {{year}} {{company}}. 모든 권리 보유.",
       "address": "대한민국 경기도 남양주시 별내3로 322, 402호",
-      "email": "siveraofficial@gmail.com",
+      "email": "sivera@sivera.app",
       "phone": "+82.010.7727.7428"
     }
   },
@@ -942,14 +942,14 @@
   },
   "consent": {
     "title": "광고 계정 접근 권한",
-    "description": "올애드가 광고 계정에 접근하기 위해 필요한 권한입니다. 선택한 플랫폼에 대해서만 접근 권한이 부여됩니다.",
+    "description": "Sivera가 광고 계정에 접근하기 위해 필요한 권한입니다. 선택한 플랫폼에 대해서만 접근 권한이 부여됩니다.",
     "selectAll": "모든 플랫폼 선택",
     "required": "필수",
     "requestedPermissions": "다음 권한이 요청됩니다:",
     "noticeTitle": "중요 안내사항",
     "bullets": {
       "revokeAnytime": "이 권한은 언제든지 설정에서 취소할 수 있습니다.",
-      "scopeOnly": "올애드는 승인된 권한 범위 내에서만 데이터에 접근합니다.",
+      "scopeOnly": "Sivera는 승인된 권한 범위 내에서만 데이터에 접근합니다.",
       "encrypted": "모든 데이터는 암호화되어 안전하게 보호됩니다.",
       "privacy": "개인정보 처리방침에 따라 데이터가 처리됩니다."
     },

--- a/app/[lang]/dictionaries/zh.json
+++ b/app/[lang]/dictionaries/zh.json
@@ -123,7 +123,7 @@
     "reports": "报告"
   },
   "brand": {
-    "name": "A.ll + Ad"
+    "name": "Sivera"
   },
   "auth": {
     "login": {
@@ -833,7 +833,7 @@
       "tagline": "为广告管理设定新标准。",
       "copyright": "© {{year}} {{company}}。保留所有权利。",
       "address": "大韩民国京畿道南杨州市别内3路322号402室",
-      "email": "siveraofficial@gmail.com",
+      "email": "sivera@sivera.app",
       "phone": "+82.010.7727.7428"
     }
   },
@@ -920,14 +920,14 @@
   },
   "consent": {
     "title": "广告账户访问权限",
-    "description": "All-AD 访问广告账户所需的权限。仅对所选平台授予访问权限。",
+    "description": "Sivera 访问广告账户所需的权限。仅对所选平台授予访问权限。",
     "selectAll": "选择所有平台",
     "required": "必需",
     "requestedPermissions": "将请求以下权限：",
     "noticeTitle": "重要说明",
     "bullets": {
       "revokeAnytime": "您可随时在设置中撤销这些权限。",
-      "scopeOnly": "All-AD 仅在授权范围内访问数据。",
+      "scopeOnly": "Sivera 仅在授权范围内访问数据。",
       "encrypted": "所有数据均已加密并安全保护。",
       "privacy": "数据将按照隐私政策进行处理。"
     },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,16 +30,16 @@ export const metadata: Metadata = {
     "kakao ads",
     "coupang ads",
   ],
-  authors: [{ name: "A.ll + Ad Team" }],
-  creator: "A.ll + Ad",
-  publisher: "A.ll + Ad",
+  authors: [{ name: "Sivera Team" }],
+  creator: "Sivera",
+  publisher: "Sivera",
   formatDetection: {
     email: false,
     address: false,
     telephone: false,
   },
   metadataBase: new URL(
-    process.env.NEXT_PUBLIC_SITE_URL || "https://alladvertising.com",
+    process.env.NEXT_PUBLIC_SITE_URL || "https://sivera.app",
   ),
   alternates: {
     canonical: "/",
@@ -70,7 +70,7 @@ export const metadata: Metadata = {
     title: siteConfig.name,
     description: siteConfig.description,
     images: ["/og-image.png"],
-    creator: "@alladvertising",
+    creator: "@sivera",
   },
   robots: {
     index: true,

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -2,8 +2,8 @@ import { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "A.ll + Ad - 모든 광고를 하나로",
-    short_name: "A.ll + Ad",
+    name: "Sivera - 모든 광고를 하나로",
+    short_name: "Sivera",
     description:
       "All-in-one advertising platform integrating multiple ad platforms",
     start_url: "/",
@@ -32,7 +32,7 @@ export default function manifest(): MetadataRoute.Manifest {
     lang: "ko-KR",
     orientation: "portrait-primary",
     scope: "/",
-    id: "alladvertising",
+    id: "sivera",
     shortcuts: [
       {
         name: "Dashboard",

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,8 +1,7 @@
 import { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || "https://alladvertising.com";
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://sivera.app";
 
   return {
     rules: [

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,8 +1,7 @@
 import { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || "https://alladvertising.com";
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://sivera.app";
 
   // Base pages
   const staticPages = ["", "/demo", "/pricing", "/support", "/contact"];

--- a/components/home/FAQSection.tsx
+++ b/components/home/FAQSection.tsx
@@ -6,14 +6,14 @@ import { title, subtitle } from "@/components/primitives";
 export const FAQSection = () => {
   const faqs = [
     {
-      question: "올애드는 어떤 광고 플랫폼을 지원하나요?",
+      question: "Sivera는 어떤 광고 플랫폼을 지원하나요?",
       answer:
         "Google Ads, Facebook Ads, Instagram Ads, YouTube Ads, Naver Ads, Kakao Ads, TikTok Ads, Amazon Ads 등 국내외 주요 광고 플랫폼을 모두 지원합니다. 지속적으로 새로운 플랫폼을 추가하고 있습니다.",
     },
     {
       question: "기존 광고 캠페인을 그대로 이전할 수 있나요?",
       answer:
-        "네, 가능합니다. 올애드는 기존 광고 플랫폼과 API 연동을 통해 현재 운영 중인 캠페인을 그대로 가져올 수 있습니다. 데이터 손실 없이 안전하게 이전됩니다.",
+        "네, 가능합니다. Sivera는 기존 광고 플랫폼과 API 연동을 통해 현재 운영 중인 캠페인을 그대로 가져올 수 있습니다. 데이터 손실 없이 안전하게 이전됩니다.",
     },
     {
       question: "최소 계약 기간이 있나요?",

--- a/components/home/TestimonialsSection.tsx
+++ b/components/home/TestimonialsSection.tsx
@@ -94,7 +94,7 @@ export const TestimonialsSection = () => {
           viewport={{ once: true }}
           whileInView={prefersReducedMotion ? undefined : { opacity: 1 }}
         >
-          <h2 className={title({ size: "md" })}>고객이 말하는 올애드</h2>
+          <h2 className={title({ size: "md" })}>고객이 말하는 Sivera</h2>
           <p className={subtitle({ class: "mt-2" })}>
             실제 사용자들의 생생한 후기를 확인하세요
           </p>


### PR DESCRIPTION
## Summary
Complete rebranding from ALLAD/ALL-AD/올애드 to Sivera across all user-facing content

### Changes Made
- **Dictionary Files**: Updated brand names in ko.json, en.json, zh.json
- **UI Components**: Updated TestimonialsSection and FAQSection
- **Metadata & Config**: Updated app manifest, sitemap, robots.txt, layout metadata
- **Legal Documents**: Updated privacy policy, cookie policy, refund policy, FAQ, terms of service
- **Domain & Email**: Changed all domain references to sivera.app and email addresses to sivera@sivera.app

### Files Modified
- Dictionary files (3): All language translations updated
- React components (2): Home page sections updated  
- App configuration (4): Manifest, sitemap, robots, layout metadata
- Legal documents (5): All policy pages updated with new branding

### Test Results
- ✅ Type checking: Passed
- ✅ Code formatting: Applied
- ✅ Linting: Passed  
- ✅ Unit tests: 109/109 tests passed

### Impact
- All user-facing text now displays "Sivera" instead of "ALLAD/ALL-AD/올애드"
- Updated domain references from alladvertising.com to sivera.app
- Updated contact email from old address to sivera@sivera.app
- Maintained backend stability by avoiding sensitive server-side changes

🤖 Generated with [Claude Code](https://claude.ai/code)